### PR TITLE
pad_framewise_output bug fix

### DIFF
--- a/pytorch/pytorch_utils.py
+++ b/pytorch/pytorch_utils.py
@@ -128,6 +128,8 @@ def pad_framewise_output(framewise_output, frames_num):
     Outputs:
       output: (batch_size, frames_num, classes_num)
     """
+    if frames_num == framewise_output.shape[1]:
+        return framewise_output 
     pad = framewise_output[:, -1 :, :].repeat(1, frames_num - framewise_output.shape[1], 1)
     """tensor for padding"""
 


### PR DESCRIPTION
Hello,

I found a minor bug that causes crashes with random audio files. In cases where framewise_output doesn't require padding, the program calls torch.Tensor.repeat(1,0,1) which is illegal.