### PR TITLE
Adding support for h5py & fix memory pinning

### DIFF
--- a/pytorch/main.py
+++ b/pytorch/main.py
@@ -72,6 +72,8 @@ def train(args):
     filename = args.filename
 
     num_workers = 8
+    prefetch_factor = 4
+    
     clip_samples = config.clip_samples
     classes_num = config.classes_num
     loss_func = get_loss_func(loss_type)
@@ -160,15 +162,15 @@ def train(args):
     # Data loader
     train_loader = torch.utils.data.DataLoader(dataset=dataset, 
         batch_sampler=train_sampler, collate_fn=collate_fn, 
-        num_workers=num_workers, pin_memory=True)
+        num_workers=num_workers, pin_memory=True, prefetch_factor=prefetch_factor)
     
     eval_bal_loader = torch.utils.data.DataLoader(dataset=dataset, 
         batch_sampler=eval_bal_sampler, collate_fn=collate_fn, 
-        num_workers=num_workers, pin_memory=True)
+        num_workers=num_workers, pin_memory=True, prefetch_factor=prefetch_factor)
 
     eval_test_loader = torch.utils.data.DataLoader(dataset=dataset, 
         batch_sampler=eval_test_sampler, collate_fn=collate_fn, 
-        num_workers=num_workers, pin_memory=True)
+        num_workers=num_workers, pin_memory=True, prefetch_factor=prefetch_factor)
 
     if 'mixup' in augmentation:
         mixup_augmenter = Mixup(mixup_alpha=1.)

--- a/utils/data_generator.py
+++ b/utils/data_generator.py
@@ -3,6 +3,7 @@ import h5py
 import csv
 import time
 import logging
+import torch
 
 from utilities import int16_to_float32
 
@@ -18,7 +19,7 @@ def read_black_list(black_list_csv):
     return black_list_names
 
 
-class AudioSetDataset(object):
+class AudioSetDataset(torch.utils.data.Dataset):
     def __init__(self, sample_rate=32000):
         """This class takes the meta of an audio clip as input, and return 
         the waveform and target of the audio clip. This class is used by DataLoader. 
@@ -70,6 +71,9 @@ class AudioSetDataset(object):
             return waveform[0 :: 4]
         else:
             raise Exception('Incorrect sample rate!')
+    
+    def __len__(self):
+        return len(hf['audio_name'])
 
 
 class Base(object):
@@ -417,6 +421,8 @@ def collate_fn(list_data_dict):
     np_data_dict = {}
     
     for key in list_data_dict[0].keys():
-        np_data_dict[key] = np.array([data_dict[key] for data_dict in list_data_dict])
+        if key == "audio_name":
+            continue
+        np_data_dict[key] = torch.tensor([data_dict[key] for data_dict in list_data_dict])
     
     return np_data_dict


### PR DESCRIPTION
Using h5py allows for faster building of the dataset.
I also noticed that your collate function first returned numpy arrays. However, memory pinning only works if the collate function returns Tensors or map/iterable of Tensors [1](https://pytorch.org/docs/stable/data.html#memory-pinning). I changed that and noticed faster training (I honestly cannot remember by how much it was faster).
Finally, I added the `prefetch_factor` argument which was missing in the `DataLoader`s.
Hope this will help.